### PR TITLE
Resolved the FMS-Server vehicleposition influx query syntax

### DIFF
--- a/components/fms-server/src/influx_reader.rs
+++ b/components/fms-server/src/influx_reader.rs
@@ -26,7 +26,7 @@ use influxrs::InfluxError;
 use crate::models::{self, GnssPositionObject, TriggerObject, VehiclePositionObject};
 
 const FILTER_FIELDS_POSITION: &'static str = formatcp!(
-    r#"filter(fn: (r) => contains(set: ["{}","{}","{}","{}","{}","{}","{}","{}", "{}"], value: r._field)"#,
+    r#"filter(fn: (r) => contains(set: ["{}","{}","{}","{}","{}","{}","{}","{}", "{}"], value: r._field))"#,
     influx_client::FIELD_CREATED_DATE_TIME,
     influx_client::FIELD_LATITUDE,
     influx_client::FIELD_LONGITUDE,


### PR DESCRIPTION
The Request: curl -v -s http://127.0.0.1:8081/rfms/vehicleposition?latestOnly=true | jq returned following error:
error retrieving vehicle positions: non-success response: '400 Bad Request', body: '{"code":"invalid","message":"compilation failed: error @6:5-8:75: expected RPAREN, got EOF"}'
**Below Influx DB query was executed:**

```
 from(bucket: "demo")
 |> range(start: 0, stop: 1693563160)
 |> filter(fn: (r) => r._measurement == "snapshot")
 |> filter(fn: (r) => r["vin"] =~ /.*/)
 |> filter(fn: (r) => r["trigger"] =~ /.*/)
 |> filter(fn: (r) => contains(set: ["createdDateTime","latitude","longitude","altitude","heading","speed","positionDateTime","tachographSpeed", "wheelBasedSpeed"], value: r._field)
 |> last()
 |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
```