### PR TITLE
Fix FMS Consumer start-up in Hono setup

### DIFF
--- a/fms-blueprint-compose-hono.yaml
+++ b/fms-blueprint-compose-hono.yaml
@@ -41,7 +41,7 @@ services:
     - "./influxdb/fms-demo.env"
     - "./hono-kafka.env"
     environment:
-      INFLUXDB_API_TOKEN_FILE: "/tmp/fms-demo.token"
+      INFLUXDB_TOKEN_FILE: "/tmp/fms-demo.token"
       KAFKA_PROPERTIES_FILE: "/app/config/kafka.properties"
       RUST_LOG: "info,fms_consumer=debug,influx_client=debug"
     volumes:


### PR DESCRIPTION
The FMS Consumer service definition in the Hono compose file uses
an outdated environment variable to specify the location of the
file to read the InfluxDB token from.

The name of the environment variable has been updated to the name
used by the influx-client package.

Fixes #11