### PR TITLE
fixes clippy finding in influx-client writer

### DIFF
--- a/components/influx-client/src/writer.rs
+++ b/components/influx-client/src/writer.rs
@@ -244,13 +244,10 @@ impl InfluxWriter {
             return;
         }
         let created_timestamp: u128 = match vehicle_status.created.clone().into_option() {
-            Some(ts) => match <Timestamp as TryInto<SystemTime>>::try_into(ts) {
-                Ok(sys_time) => sys_time.duration_since(UNIX_EPOCH).unwrap().as_millis(),
-                Err(e) => {
-                    debug!("ignoring vehicle status with improper created timestamp: {e}");
-                    return;
-                },
-            },
+            Some(ts) => <Timestamp as Into<SystemTime>>::into(ts)
+                                    .duration_since(UNIX_EPOCH)
+                                    .unwrap()
+                                    .as_millis(),
             None => {
                 debug!("ignoring vehicle status without created timestamp");
                 return;


### PR DESCRIPTION
The lint_source_code workflow uses the latest rust version which currently is 1.75.0. There was an additional finding in the existing code basis which should be fixed by this PR. 

For details on the finding see: https://github.com/eclipse-sdv-blueprints/fleet-management/actions/runs/7526518962/job/20484846439?pr=35