### PR TITLE
Update to latest release of influxrs crate

### DIFF
--- a/components/Cargo.lock
+++ b/components/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -348,7 +348,7 @@ checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
 dependencies = [
  "csv-core",
  "itoa",
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
 ]
@@ -1114,7 +1114,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1199,7 +1199,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "influxrs"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7862dbbb5d65b8a96c7b84738e32fc275d68d055f97577416c16298df00791f7"
+checksum = "ae2b0b3d0ecac700fd3b3833d8faf40e3606e9759fa232758998a098a69670c5"
 dependencies = [
  "csv",
  "isahc",
@@ -2027,7 +2027,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2068,7 +2068,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2175,7 +2175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2190,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2224,7 +2224,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.43",
+ "syn 2.0.79",
  "tempfile",
  "which",
 ]
@@ -2239,7 +2239,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2354,9 +2354,9 @@ checksum = "9653c3ed92974e34c5a6e0a510864dab979760481714c172e0a34e437cb98804"
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -2694,22 +2694,22 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2915,9 +2915,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.43"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2960,7 +2960,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3047,7 +3047,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3144,7 +3144,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3200,7 +3200,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3479,7 +3479,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -3513,7 +3513,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3925,7 +3925,7 @@ checksum = "a9a48c9ddfe781b4d75a2372086db3c3f8ff993e222eb3b9328f62cbdec90af3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
  "zenoh-keyexpr",
 ]
 
@@ -4089,7 +4089,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/components/Cargo.toml
+++ b/components/Cargo.toml
@@ -39,7 +39,7 @@ env_logger = { version = "0.11", default-features = false, features = [
 ] }
 fms-proto = { path = "fms-proto" }
 influx-client = { path = "influx-client", default-features = false }
-influxrs = { version = "2.0" }
+influxrs = { version = "3.0", default-features = false }
 log = { version = "0.4" }
 protobuf = { version = "3.5.1" }
 protobuf-codegen = { version = "3.5.1" }

--- a/components/Dockerfile.fms-consumer
+++ b/components/Dockerfile.fms-consumer
@@ -32,13 +32,13 @@ RUN apt-get update && apt-get install -y ca-certificates \
 # This will speed up fetching the crate.io index in the future, see
 # https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html
 ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
+RUN cargo install cargo-about
 
 RUN echo "Building for $TARGETARCH"
 RUN mkdir components
 COPY . components/
 WORKDIR /home/rust/src/components/fms-consumer
 
-RUN cargo install cargo-about
 RUN cargo about generate -o /home/rust/licenses.html ../about.hbs
 RUN cargo build --release --target $BUILDTARGET
 RUN mv ../target/${BUILDTARGET}/release/fms-consumer /home/rust

--- a/components/Dockerfile.fms-forwarder
+++ b/components/Dockerfile.fms-forwarder
@@ -34,13 +34,13 @@ ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
 # This is supposedly required for successfully building for arm64 using buildx with QEMU
 # see https://github.com/rust-lang/cargo/issues/10583
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+RUN cargo install cargo-about
 
 RUN echo "Building for $TARGETARCH"
 RUN mkdir components
 COPY . components/
 WORKDIR /home/rust/src/components/fms-forwarder
 
-RUN cargo install cargo-about
 RUN cargo about generate -o /home/rust/licenses.html ../about.hbs
 RUN cargo build --release --target $BUILDTARGET
 RUN mv ../target/${BUILDTARGET}/release/fms-forwarder /home/rust

--- a/components/Dockerfile.fms-server
+++ b/components/Dockerfile.fms-server
@@ -30,13 +30,13 @@ ARG TARGETARCH
 # This will speed up fetching the crate.io index in the future, see
 # https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html
 ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
+RUN cargo install cargo-about
 
 RUN echo "Building for $TARGETARCH"
 RUN mkdir components
 COPY . components/
 WORKDIR /home/rust/src/components/fms-server
 
-RUN cargo install cargo-about
 RUN cargo about generate -o /home/rust/licenses.html ../about.hbs
 RUN cargo build --release --target $BUILDTARGET
 RUN mv ../target/${BUILDTARGET}/release/fms-server /home/rust

--- a/components/fms-server/Cargo.toml
+++ b/components/fms-server/Cargo.toml
@@ -45,7 +45,7 @@ clap = { workspace = true, features = [
 const_format = { version = "0.2" }
 env_logger = { workspace = true }
 influx-client = { workspace = true }
-influxrs = { workspace = true }
+influxrs = { workspace = true, features = ["client"] }
 log = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/components/influx-client/Cargo.toml
+++ b/components/influx-client/Cargo.toml
@@ -41,7 +41,7 @@ clap = { workspace = true, features = [
 ] }
 fms-proto = { workspace = true, optional = true }
 protobuf = { workspace = true, optional = true }
-influxrs = { workspace = true }
+influxrs = { workspace = true, features = ["client"] }
 isahc = { version = "1.7", default-features = false, features = [
     "http2",
     "static-ssl",


### PR DESCRIPTION
The influxrs crate has received a few commits recently which have
resulted in a new major release. Thus, there is no need to migrate
to another InfluxDB client (yet).

Fixes #42