### PR TITLE
Update to influxrs 3.0.1

### DIFF
--- a/components/Cargo.lock
+++ b/components/Cargo.lock
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "influxrs"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2b0b3d0ecac700fd3b3833d8faf40e3606e9759fa232758998a098a69670c5"
+checksum = "03afc8a4c6452678daa690a20f48efe1c81e037ba65eca22560078c831b430a8"
 dependencies = [
  "csv",
  "isahc",

--- a/components/Cargo.toml
+++ b/components/Cargo.toml
@@ -39,7 +39,7 @@ env_logger = { version = "0.11", default-features = false, features = [
 ] }
 fms-proto = { path = "fms-proto" }
 influx-client = { path = "influx-client", default-features = false }
-influxrs = { version = "3.0", default-features = false }
+influxrs = { version = "3.0.1", default-features = false }
 log = { version = "0.4" }
 protobuf = { version = "3.5.1" }
 protobuf-codegen = { version = "3.5.1" }


### PR DESCRIPTION
The 3.0.0 release of the influxrs crate contained a bug which prevented
writing to InfluxDB (https://github.com/ijagberg/influx/issues/7).

Changed Cargo.toml to require at least version 3.0.1 in order to fix
the issue.