### PR TITLE
docs: fix broken image link

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -11,5 +11,5 @@ title: Introduction
 |What is in the showcase | In-vehicle data collection using VSS Signal Specification, data transfer to cloud back end, rFMS server|
 |SDV Projects Involved| Eclipse Leda, Eclipse Kuksa |
 |Other interesting Technologies|InfluxDB, Eclipse Hono, Eclipse Kanto, Eclipse Paho |
-| Architecture Overview | ![FleetArchSDV](../img/architecture.drawio.svg)|
+| Architecture Overview | ![FleetArchSDV](../img/architecture-uprotocol.drawio.svg)|
 | Distro | TBD |


### PR DESCRIPTION
Fix the broken link in `introduction.md` file that is causing the deployment of [Blueprints Website](https://github.com/eclipse-sdv-blueprints/blueprints-website/actions/runs/22480605498/job/65117588177) to fail. 


```bash
$ yarn build
Error: Image docs/img/architecture.drawio.svg used in docs/fleet-management/introduction.md not found.
```

Production build fails because of a missing image reference